### PR TITLE
Fixed screen output

### DIFF
--- a/source/draw.c
+++ b/source/draw.c
@@ -58,16 +58,15 @@ void DrawString(u8* screen, const char *str, int x, int y, int color, int bgcolo
 
 void DrawStringF(int x, int y, const char *format, ...)
 {
-    char* str;
+    char str[256];
     va_list va;
 
     va_start(va, format);
-    vasprintf(&str, format, va);
+    vsnprintf(str, 256, format, va);
     va_end(va);
 
     DrawString(TOP_SCREEN0, str, x, y, FONT_COLOR, BG_COLOR);
     DrawString(TOP_SCREEN1, str, x, y, FONT_COLOR, BG_COLOR);
-    free(str);
 }
 
 void DebugClear()
@@ -79,16 +78,19 @@ void DebugClear()
 
 void Debug(const char *format, ...)
 {
-    char* str;
+    char str[256];
     va_list va;
 
     va_start(va, format);
-    vasprintf(&str, format, va);
+    vsnprintf(str, 256, format, va);
     va_end(va);
+	
+	if (current_y >= END_Y) {
+        DebugClear();
+    }
 
     DrawString(TOP_SCREEN0, str, 10, current_y, FONT_COLOR, BG_COLOR);
     DrawString(TOP_SCREEN1, str, 10, current_y, FONT_COLOR, BG_COLOR);
-    free(str);
 
     current_y += 10;
 }

--- a/source/draw.h
+++ b/source/draw.h
@@ -18,6 +18,7 @@
 #define TOP_SCREEN1 (u8*)(0x20046500)
 #define BOT_SCREEN0 (u8*)(0x2008CA00)
 #define BOT_SCREEN1 (u8*)(0x200C4E00)
+extern int current_y;
 
 void ClearScreen(unsigned char *screen, int color);
 void DrawCharacter(unsigned char *screen, int character, int x, int y, int color, int bgcolor);


### PR DESCRIPTION
vasprintf() breaks the output for me (on Brahma)

Clearing the screen makes sense, because some ncchinfo.bin files
completely fill the screen with Debug messages, leading to bad output
otherwise.

current_y should not be modified externally, but you may want to put it
back in if you intended to use that.