### PR TITLE
Fixed screen output

### DIFF
--- a/source/decryptor/decryptor.h
+++ b/source/decryptor/decryptor.h
@@ -77,4 +77,8 @@ typedef struct {
     TitleKeyEntry entries[MAX_ENTRIES];
 } __attribute__((packed, aligned(16))) EncKeysInfo;
 
+static u8* FindNandCtr();
+u32 DumpPartition(char* filename, u32 offset, u32 size, u32 keyslot);
+u32 DecryptBuffer(DecryptBufferInfo *info);
 u32 CreatePad(PadInfo *info);
+

--- a/source/decryptor/features.h
+++ b/source/decryptor/features.h
@@ -5,4 +5,5 @@ u32 SdPadgen(void);
 u32 NandPadgen(void);
 u32 DecryptTitlekeys(void);
 u32 NandDumper(void);
-u32 NandPartitionsDumper();
+u32 NandPartitionsDumper(void);
+u32 TicketDumper(void);

--- a/source/draw.c
+++ b/source/draw.c
@@ -58,16 +58,15 @@ void DrawString(u8* screen, const char *str, int x, int y, int color, int bgcolo
 
 void DrawStringF(int x, int y, const char *format, ...)
 {
-    char* str;
+    char str[256];
     va_list va;
 
     va_start(va, format);
-    vasprintf(&str, format, va);
+    vsnprintf(str, 256, format, va);
     va_end(va);
 
     DrawString(TOP_SCREEN0, str, x, y, FONT_COLOR, BG_COLOR);
     DrawString(TOP_SCREEN1, str, x, y, FONT_COLOR, BG_COLOR);
-    free(str);
 }
 
 void DebugClear()
@@ -79,16 +78,19 @@ void DebugClear()
 
 void Debug(const char *format, ...)
 {
-    char* str;
+    char str[256];
     va_list va;
 
     va_start(va, format);
-    vasprintf(&str, format, va);
+    vsnprintf(str, 256, format, va);
     va_end(va);
+	
+	if (current_y >= END_Y) {
+        DebugClear();
+    }
 
     DrawString(TOP_SCREEN0, str, 10, current_y, FONT_COLOR, BG_COLOR);
     DrawString(TOP_SCREEN1, str, 10, current_y, FONT_COLOR, BG_COLOR);
-    free(str);
 
     current_y += 10;
 }

--- a/source/main.c
+++ b/source/main.c
@@ -26,6 +26,7 @@ int main()
     Debug("Y: NAND Padgen");
     Debug("L: NAND Partition Dump");
     Debug("R: NAND Dump");
+	Debug("%c: Ticket Dump", 0x18);
     Debug("");
     Debug("START: Reboot");
     Debug("");
@@ -57,6 +58,10 @@ int main()
         } else if (pad_state & BUTTON_R1) {
             DebugClear();
             Debug("NAND Dump: %s!", NandDumper() == 0 ? "succeeded" : "failed");
+            break;
+        } else if (pad_state & BUTTON_UP) {
+            DebugClear();
+            Debug("Ticket Dump: %s!", TicketDumper() == 0 ? "succeeded" : "failed");
             break;
         } else if (pad_state & BUTTON_START) {
             goto reboot;


### PR DESCRIPTION
vasprintf() breaks the output for me (on Brahma)

Clearing the screen makes sense, because some ncchinfo.bin files
completely fill the screen with Debug messages, leading to bad output
otherwise.